### PR TITLE
MB-53 extend mongoose schemas for request, response, feedback with log field

### DIFF
--- a/src/models/feedback.js
+++ b/src/models/feedback.js
@@ -11,6 +11,10 @@ const processFeedbackSchema = new mongoose.Schema(
       type: Boolean,
       required: true,
     },
+    log: {
+      type: Map,
+      of: Date,
+    },
   },
   { timestamps: true, discriminatorKey: 'kind' }
 );

--- a/src/models/request.js
+++ b/src/models/request.js
@@ -41,6 +41,10 @@ const requestSchema = new mongoose.Schema(
     privacyAgreed: Boolean,
     raw: String,
     locale: String,
+    log: {
+      type: Map,
+      of: Date,
+    },
   },
   { timestamps: true }
 );

--- a/src/models/response.js
+++ b/src/models/response.js
@@ -14,6 +14,10 @@ const responseSchema = new mongoose.Schema(
       enum: statusStages,
       required: true,
     },
+    log: {
+      type: Map,
+      of: Date,
+    },
   },
   { timestamps: true }
 );


### PR DESCRIPTION
Usage:

request = models.Request.findOne({});

const acceptedTimestamp = request.log.get('accepted');

request.log.set('done', Date.now);
request.save();